### PR TITLE
Prefix monorepo applications

### DIFF
--- a/bin/hellgrid
+++ b/bin/hellgrid
@@ -14,7 +14,7 @@ ARGV.each do |folder|
 
   Find.find(folder) do |path|
     if File.directory?(path) && File.exists?(File.join(path, 'Gemfile.lock'))
-      matrix.add_project(Hellgrid::Project.new(path))
+      matrix.add_project(Hellgrid::Project.new(folder, path))
       Find.prune
     end
   end

--- a/lib/hellgrid/project.rb
+++ b/lib/hellgrid/project.rb
@@ -2,12 +2,13 @@ module Hellgrid
   class Project
     attr_reader :path
 
-    def initialize(path)
+    def initialize(root, path)
+      @root = root
       @path = path
     end
 
     def name
-      File.basename(File.expand_path(path))
+      File.expand_path(path).gsub(File.expand_path(root) + '/', '')
     end
 
     def dependency_matrix
@@ -16,8 +17,10 @@ module Hellgrid
 
     private
 
+    attr_reader :root
+
     def lockfile
-      File.join(@path, 'Gemfile.lock')
+      File.join(path, 'Gemfile.lock')
     end
 
     def parsed_lockfile

--- a/spec/hellgrid/project_spec.rb
+++ b/spec/hellgrid/project_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe Hellgrid::Project do
-  subject(:project) { described_class.new(project_path) }
+  subject(:project) { described_class.new(root_path, project_path) }
 
+  let(:root_path) { 'spec' }
   let(:project_path) { 'spec/tmp/foo/' }
   let(:lockfile_path) { File.join project_path, 'Gemfile.lock' }
 
@@ -36,6 +37,12 @@ DEPENDENCIES
   rspec (= 3.0.0)
 
 FOO_GEMFILE
+  end
+
+  describe '#name' do
+    it 'returns the relative path from the root' do
+      expect(subject.name).to eq('tmp/foo')
+    end
   end
 
   describe '#dependency_matrix' do

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -4,7 +4,7 @@ describe 'bin/hellgrid' do
   before do
     delete_tmp_folder
 
-    create_file 'spec/tmp/foo/Gemfile.lock', <<-FOO_GEMFILE
+    create_file 'spec/tmp/in/foo/Gemfile.lock', <<-FOO_GEMFILE
 GEM
   remote: https://rubygems.org/
   specs:
@@ -61,7 +61,7 @@ BAR_GEMFILE
 
   it 'returns a matrix with the versions of all used gems' do
     expected_result = <<-TABLE
-         x          |  bar   |  foo   
+         x          |  bar   | in/foo 
 --------------------+--------+--------
       diff-lcs      | 1.2.5  | 1.2.5  
         rake        | 10.0.0 | 11.1.0 
@@ -77,7 +77,7 @@ TABLE
 
   it 'could be run from random directory' do
     expected_result = <<-TABLE
-         x          |  bar   |  foo   
+         x          |  bar   | in/foo 
 --------------------+--------+--------
       diff-lcs      | 1.2.5  | 1.2.5  
         rake        | 10.0.0 | 11.1.0 


### PR DESCRIPTION
If there is a repository which contains multiple Ruby projects with separate `Gemfile`s, currently the project is displayed as the directory name.

However, most repositories use names that are meaningful within context, so `lawnmover/starter` is better than `starter`.

This changeset decorates nested applications with the name relative to the root directory.
