### PR TITLE
Fix the not a git repo error when running the executable

### DIFF
--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -1,4 +1,6 @@
-lib = File.expand_path('../lib', __FILE__)
+project_root = File.dirname(__FILE__)
+lib = File.join(project_root, 'lib')
+
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hellgrid/version'
 
@@ -6,15 +8,15 @@ Gem::Specification.new do |s|
   s.name          = 'hellgrid'
   s.version       = Hellgrid::VERSION
   s.date          = '2016-03-28'
-  s.summary       = 'Gem version dependecy matrix'
+  s.summary       = 'Gem version dependency matrix'
   s.description   = ''
   s.authors       = ['Deyan Dobrinov', 'Aleksandar Ivanov']
   s.email         = ['deyan.dobrinov@gmail.com', 'aivanov92@gmail.com']
-  s.files         = `git ls-files -z`.split("\x0")
-  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
+  s.files         = Dir.chdir(project_root) { Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['spec/**/*.rb'] + %w(Gemfile Gemfile.lock README.md hellgrid.gemspec) }
+  s.executables   = s.files.grep(/^bin\//) { |f| File.basename(f) }
+  s.test_files    = s.files.grep(/^spec\//)
   s.require_paths = ['lib']
-  s.homepage      = 'http://github.com/FundingCircle/hellgrid'
+  s.homepage      = 'https://github.com/FundingCircle/hellgrid'
   s.license       = 'MIT'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'


### PR DESCRIPTION
'fatal: Not a git repository (or any of the parent directories): .git'
was caused by the git ls-files in the gemspec

We were requiring it the executable. The files for the gemspec are now
manually loaded. The chdir is there so that we always load the correct
files. (the current dir could be bogus)
