### PR TITLE
Recursive find

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hellgrid (0.0.1)
+    hellgrid (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -30,4 +30,4 @@ DEPENDENCIES
   rspec (~> 3.4, >= 3.4.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hellgrid (0.1.0)
+    hellgrid (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,4 +30,4 @@ DEPENDENCIES
   rspec (~> 3.4, >= 3.4.0)
 
 BUNDLED WITH
-   1.12.5
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Executing:
 hellgrid /path/to/root/dir
 ```
 
+To search recursively (should you have nested projects), use the `-r ` flag:
+```
+hellgrid -r /path/to/root/dir
+```
+
 Should result in:
 ```bash
              x             |  bar   |  foo

--- a/bin/hellgrid
+++ b/bin/hellgrid
@@ -9,6 +9,7 @@ require 'find'
 
 require 'hellgrid'
 
+recursive_search = !!(ARGV.delete('-r'))
 folders = ARGV.empty? ? [Dir.pwd] : ARGV
 
 folders.each do |folder|
@@ -17,7 +18,7 @@ folders.each do |folder|
   Find.find(folder) do |path|
     if File.directory?(path) && File.exists?(File.join(path, 'Gemfile.lock'))
       matrix.add_project(Hellgrid::Project.new(folder, path))
-      Find.prune
+      Find.prune unless recursive_search
     end
   end
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.3.0
+    version: 2.3.1
 
 dependencies:
   pre:

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'
   s.license       = 'MIT'
 
+  s.required_ruby_version = '>= 2.3.1'
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'bundler', '~> 1.11', '>= 1.11.0'
 end

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/hellgrid/project_spec.rb
+++ b/spec/hellgrid/project_spec.rb
@@ -10,33 +10,33 @@ describe Hellgrid::Project do
   before do
     delete_tmp_folder
 
-    create_file lockfile_path, <<-FOO_GEMFILE
-GEM
-  remote: https://rubygems.org/
-  specs:
-    diff-lcs (1.2.5)
-    rake (11.1.0)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.4)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.4)
+    create_file lockfile_path,  <<~FOO_GEMFILE
+                                  GEM
+                                    remote: https://rubygems.org/
+                                    specs:
+                                      diff-lcs (1.2.5)
+                                      rake (11.1.0)
+                                      rspec (3.0.0)
+                                        rspec-core (~> 3.0.0)
+                                        rspec-expectations (~> 3.0.0)
+                                        rspec-mocks (~> 3.0.0)
+                                      rspec-core (3.0.4)
+                                        rspec-support (~> 3.0.0)
+                                      rspec-expectations (3.0.4)
+                                        diff-lcs (>= 1.2.0, < 2.0)
+                                        rspec-support (~> 3.0.0)
+                                      rspec-mocks (3.0.4)
+                                        rspec-support (~> 3.0.0)
+                                      rspec-support (3.0.4)
 
-PLATFORMS
-  ruby
+                                  PLATFORMS
+                                    ruby
 
-DEPENDENCIES
-  rake (= 11.1.0)
-  rspec (= 3.0.0)
+                                  DEPENDENCIES
+                                    rake (= 11.1.0)
+                                    rspec (= 3.0.0)
 
-FOO_GEMFILE
+                                FOO_GEMFILE
   end
 
   describe '#name' do

--- a/spec/hellgrid/views/console_spec.rb
+++ b/spec/hellgrid/views/console_spec.rb
@@ -13,14 +13,14 @@ describe Hellgrid::Views::Console do
 
   describe '#render_as_string' do
     it 'renders matrix' do
-      expected_result = <<-TABLE
- x |  bar  |  foo  
----+-------+-------
- b | 2.0.2 | 2.0.1 
- c | 3.0.2 | 3.0.1 
- a |   x   | 1.0.1 
- d | 4.0.2 |   x   
-TABLE
+      expected_result = <<~TABLE
+                           x |  bar  |  foo  
+                          ---+-------+-------
+                           b | 2.0.2 | 2.0.1 
+                           c | 3.0.2 | 3.0.1 
+                           a |   x   | 1.0.1 
+                           d | 4.0.2 |   x   
+                        TABLE
 
       expect(console.render_as_string).to eq(expected_result)
     end

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -110,4 +110,24 @@ describe 'bin/hellgrid' do
       expect(`cd #{PROJECT_ROOT}/spec/tmp && #{PROJECT_ROOT}/bin/hellgrid`).to eq(expected_result)
     end
   end
+
+  it 'searches recursively within folders if you flag it to' do
+    expected_result =
+    <<~TABLE
+               x          | /Users/sashacooper/Desktop/pogroms/jobs/hellgrid | spec/tmp/bar | spec/tmp/in/foo 
+      --------------------+--------------------------------------------------+--------------+-----------------
+            diff-lcs      |                      1.2.5                       |    1.2.5     |      1.2.5      
+             rspec        |                      3.4.0                       |    2.0.0     |      3.0.0      
+           rspec-core     |                      3.4.2                       |    2.0.0     |      3.0.4      
+       rspec-expectations |                      3.4.0                       |    2.0.0     |      3.0.4      
+          rspec-mocks     |                      3.4.1                       |    2.0.0     |      3.0.4      
+              rake        |                        x                         |    10.0.0    |     11.1.0      
+         rspec-support    |                      3.4.1                       |      x       |      3.0.4      
+            hellgrid      |                      0.1.0                       |      x       |        x        
+    TABLE
+
+    Bundler.with_clean_env do
+      expect(`cd #{PROJECT_ROOT} && hellgrid -r`).to eq(expected_result)
+    end
+  end
 end

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -4,89 +4,89 @@ describe 'bin/hellgrid' do
   before do
     delete_tmp_folder
 
-    create_file 'spec/tmp/in/foo/Gemfile.lock', <<-FOO_GEMFILE
-GEM
-  remote: https://rubygems.org/
-  specs:
-    diff-lcs (1.2.5)
-    rake (11.1.0)
-    rspec (3.0.0)
-      rspec-core (~> 3.0.0)
-      rspec-expectations (~> 3.0.0)
-      rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.4)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.4)
-      rspec-support (~> 3.0.0)
-    rspec-support (3.0.4)
+    create_file 'spec/tmp/in/foo/Gemfile.lock', <<~FOO_GEMFILE
+                                                  GEM
+                                                    remote: https://rubygems.org/
+                                                    specs:
+                                                      diff-lcs (1.2.5)
+                                                      rake (11.1.0)
+                                                      rspec (3.0.0)
+                                                        rspec-core (~> 3.0.0)
+                                                        rspec-expectations (~> 3.0.0)
+                                                        rspec-mocks (~> 3.0.0)
+                                                      rspec-core (3.0.4)
+                                                        rspec-support (~> 3.0.0)
+                                                      rspec-expectations (3.0.4)
+                                                        diff-lcs (>= 1.2.0, < 2.0)
+                                                        rspec-support (~> 3.0.0)
+                                                      rspec-mocks (3.0.4)
+                                                        rspec-support (~> 3.0.0)
+                                                      rspec-support (3.0.4)
 
-PLATFORMS
-  ruby
+                                                  PLATFORMS
+                                                    ruby
 
-DEPENDENCIES
-  rake (= 11.1.0)
-  rspec (= 3.0.0)
+                                                  DEPENDENCIES
+                                                    rake (= 11.1.0)
+                                                    rspec (= 3.0.0)
 
-FOO_GEMFILE
+                                                FOO_GEMFILE
 
-    create_file 'spec/tmp/bar/Gemfile.lock', <<-BAR_GEMFILE
-GEM
-  remote: https://rubygems.org/
-  specs:
-    diff-lcs (1.2.5)
-    rake (10.0.0)
-    rspec (2.0.0)
-      rspec-core (= 2.0.0)
-      rspec-expectations (= 2.0.0)
-      rspec-mocks (= 2.0.0)
-    rspec-core (2.0.0)
-    rspec-expectations (2.0.0)
-      diff-lcs (>= 1.1.2)
-    rspec-mocks (2.0.0)
-      rspec-core (= 2.0.0)
-      rspec-expectations (= 2.0.0)
+    create_file 'spec/tmp/bar/Gemfile.lock',  <<~BAR_GEMFILE
+                                                GEM
+                                                  remote: https://rubygems.org/
+                                                  specs:
+                                                    diff-lcs (1.2.5)
+                                                    rake (10.0.0)
+                                                    rspec (2.0.0)
+                                                      rspec-core (= 2.0.0)
+                                                      rspec-expectations (= 2.0.0)
+                                                      rspec-mocks (= 2.0.0)
+                                                    rspec-core (2.0.0)
+                                                    rspec-expectations (2.0.0)
+                                                      diff-lcs (>= 1.1.2)
+                                                    rspec-mocks (2.0.0)
+                                                      rspec-core (= 2.0.0)
+                                                      rspec-expectations (= 2.0.0)
 
-PLATFORMS
-  ruby
+                                                PLATFORMS
+                                                  ruby
 
-DEPENDENCIES
-  rake (= 10.0.0)
-  rspec (= 2.0.0)
+                                                DEPENDENCIES
+                                                  rake (= 10.0.0)
+                                                  rspec (= 2.0.0)
 
-BAR_GEMFILE
+                                              BAR_GEMFILE
   end
 
   it 'returns a matrix with the versions of all used gems' do
-    expected_result = <<-TABLE
-         x          |  bar   | in/foo 
---------------------+--------+--------
-      diff-lcs      | 1.2.5  | 1.2.5  
-        rake        | 10.0.0 | 11.1.0 
-       rspec        | 2.0.0  | 3.0.0  
-     rspec-core     | 2.0.0  | 3.0.4  
- rspec-expectations | 2.0.0  | 3.0.4  
-    rspec-mocks     | 2.0.0  | 3.0.4  
-   rspec-support    |   x    | 3.0.4  
-TABLE
+    expected_result = <<~TABLE
+                                 x          |  bar   | in/foo 
+                        --------------------+--------+--------
+                              diff-lcs      | 1.2.5  | 1.2.5  
+                                rake        | 10.0.0 | 11.1.0 
+                               rspec        | 2.0.0  | 3.0.0  
+                             rspec-core     | 2.0.0  | 3.0.4  
+                         rspec-expectations | 2.0.0  | 3.0.4  
+                            rspec-mocks     | 2.0.0  | 3.0.4  
+                           rspec-support    |   x    | 3.0.4  
+                      TABLE
 
     expect(`#{PROJECT_ROOT}/bin/hellgrid #{PROJECT_ROOT}/spec/tmp`).to eq(expected_result)
   end
 
   it 'could be run from random directory' do
-    expected_result = <<-TABLE
-         x          |  bar   | in/foo 
---------------------+--------+--------
-      diff-lcs      | 1.2.5  | 1.2.5  
-        rake        | 10.0.0 | 11.1.0 
-       rspec        | 2.0.0  | 3.0.0  
-     rspec-core     | 2.0.0  | 3.0.4  
- rspec-expectations | 2.0.0  | 3.0.4  
-    rspec-mocks     | 2.0.0  | 3.0.4  
-   rspec-support    |   x    | 3.0.4  
-TABLE
+    expected_result = <<~TABLE
+                                 x          |  bar   | in/foo 
+                        --------------------+--------+--------
+                              diff-lcs      | 1.2.5  | 1.2.5  
+                                rake        | 10.0.0 | 11.1.0 
+                               rspec        | 2.0.0  | 3.0.0  
+                             rspec-core     | 2.0.0  | 3.0.4  
+                         rspec-expectations | 2.0.0  | 3.0.4  
+                            rspec-mocks     | 2.0.0  | 3.0.4  
+                           rspec-support    |   x    | 3.0.4  
+                      TABLE
 
     Bundler.with_clean_env do
       expect(`cd ~ && #{PROJECT_ROOT}/bin/hellgrid #{PROJECT_ROOT}/spec/tmp`).to eq(expected_result)
@@ -94,17 +94,17 @@ TABLE
   end
 
   it 'uses the current working directory by default' do
-    expected_result = <<-TABLE
-         x          |  bar   | in/foo 
---------------------+--------+--------
-      diff-lcs      | 1.2.5  | 1.2.5  
-        rake        | 10.0.0 | 11.1.0 
-       rspec        | 2.0.0  | 3.0.0  
-     rspec-core     | 2.0.0  | 3.0.4  
- rspec-expectations | 2.0.0  | 3.0.4  
-    rspec-mocks     | 2.0.0  | 3.0.4  
-   rspec-support    |   x    | 3.0.4  
-TABLE
+    expected_result = <<~TABLE
+                                 x          |  bar   | in/foo 
+                        --------------------+--------+--------
+                              diff-lcs      | 1.2.5  | 1.2.5  
+                                rake        | 10.0.0 | 11.1.0 
+                               rspec        | 2.0.0  | 3.0.0  
+                             rspec-core     | 2.0.0  | 3.0.4  
+                         rspec-expectations | 2.0.0  | 3.0.4  
+                            rspec-mocks     | 2.0.0  | 3.0.4  
+                           rspec-support    |   x    | 3.0.4  
+                      TABLE
 
     Bundler.with_clean_env do
       expect(`cd #{PROJECT_ROOT}/spec/tmp && #{PROJECT_ROOT}/bin/hellgrid`).to eq(expected_result)

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -123,7 +123,7 @@ describe 'bin/hellgrid' do
           rspec-mocks     |                      3.4.1                       |    2.0.0     |      3.0.4      
               rake        |                        x                         |    10.0.0    |     11.1.0      
          rspec-support    |                      3.4.1                       |      x       |      3.0.4      
-            hellgrid      |                      0.1.0                       |      x       |        x        
+            hellgrid      |                      0.2.0                       |      x       |        x        
     TABLE
 
     Bundler.with_clean_env do


### PR DESCRIPTION
Hi all,

This is a minor contribution to a) enable recursive searching in nested projects if the user wants it, and b) update the specs to use the much prettier Ruby 2.3 squiggly heredoc syntax. It does mean that the gem requires Ruby 2.3.1 to run (squiggly heredoc in 2.3.0 seems to be buggy).

Kind regards,

Sasha
