### PR TITLE
Attach correct license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2016, Funding Circle
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Should result in:
        rspec-support       |   x    | 3.0.4
           hellgrid         |   x    |   x
 ```
+
+## License
+
+Copyright © 2016 Funding Circle.
+
+Distributed under the BSD 3-Clause License.

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -7,7 +7,7 @@ require 'hellgrid/version'
 Gem::Specification.new do |s|
   s.name          = 'hellgrid'
   s.version       = Hellgrid::VERSION
-  s.date          = '2016-03-28'
+  s.date          = '2016-09-20'
   s.summary       = 'Gem version dependency matrix'
   s.description   = ''
   s.authors       = ['Deyan Dobrinov', 'Aleksandar Ivanov']
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(/^spec\//)
   s.require_paths = ['lib']
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'
-  s.license       = 'MIT'
+  s.license       = 'BSD-3'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'bundler', '~> 1.11', '>= 1.11.0'

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -9,9 +9,8 @@ Gem::Specification.new do |s|
   s.version       = Hellgrid::VERSION
   s.date          = '2016-09-20'
   s.summary       = 'Gem version dependency matrix'
-  s.description   = ''
   s.authors       = ['Deyan Dobrinov', 'Aleksandar Ivanov']
-  s.email         = ['deyan.dobrinov@gmail.com', 'aivanov92@gmail.com']
+  s.email         = ['engineering+hellgrid@fundingcircle.com']
   s.files         = Dir.chdir(project_root) { Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['spec/**/*.rb'] + %w(Gemfile Gemfile.lock README.md hellgrid.gemspec) }
   s.executables   = s.files.grep(/^bin\//) { |f| File.basename(f) }
   s.test_files    = s.files.grep(/^spec\//)

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
💁  Funding Circle releases software under the BSD-3 Clause license. This change attaches the correct license and bumps the version.
