### PR TITLE
Use correct license name and bump the version to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hellgrid (0.2.0)
+    hellgrid (0.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -30,4 +30,4 @@ DEPENDENCIES
   rspec (~> 3.4, >= 3.4.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(/^spec\//)
   s.require_paths = ['lib']
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'
-  s.license       = 'BSD-3'
+  s.license       = 'BSD-3-Clause'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'bundler', '~> 1.11', '>= 1.11.0'

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
The correct short name of the bsd3 license that we use is BSD-3-Clause

* https://spdx.org/licenses/BSD-3-Clause.html
* https://spdx.org/licenses/

The v0.3.0 is set here because the change for the recursive search
didn't update it. It was changed to 0.2.0 from the PR for the license.