### PR TITLE
Fix bundler dependency

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,13 @@ jobs:
           paths:
             - vendor/bundle
       - run: bundle exec rspec spec --format progress
+      - run:
+          name: Make sure that the gem runs when installed
+          command: |
+            set -e
+            gem build 'hellgrid.gemspec'
+            gem install $(ls -t1 hellgrid-*.gem | head -1)
+            cd ~ && hellgrid
   deploy:
     <<: *defaults
     steps:

--- a/exe/hellgrid
+++ b/exe/hellgrid
@@ -3,10 +3,7 @@
 require 'pathname'
 # XXX: BUNDLE_GEMFILE should be provided because the internals of bundler require a 'Gemfile' or '.bundle' to
 # work properly. Without this the script will fail if there isn't a Gemfile somewhere up the directory chain
-ENV['BUNDLE_GEMFILE'] ||= File.join(File.expand_path('../..', Pathname.new(__FILE__).realpath), 'Gemfile')
-
-require 'rubygems'
-require 'bundler/setup'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', Pathname.new(__FILE__).realpath)
 
 require 'hellgrid'
 

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -11,8 +11,9 @@ Gem::Specification.new do |s|
   s.summary       = 'Gem version dependency matrix'
   s.authors       = ['Deyan Dobrinov', 'Aleksandar Ivanov']
   s.email         = ['engineering+hellgrid@fundingcircle.com']
-  s.files         = Dir.chdir(project_root) { Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['spec/**/*.rb'] + %w(Gemfile Gemfile.lock README.md hellgrid.gemspec) }
-  s.executables   = s.files.grep(/^bin\//) { |f| File.basename(f) }
+  s.files         = Dir.chdir(project_root) { Dir['lib/**/*.rb'] + Dir['bin/*'] + Dir['exe/*'] + Dir['spec/**/*.rb'] + %w(Gemfile Gemfile.lock README.md hellgrid.gemspec) }
+  s.bindir        = 'exe'
+  s.executables   = s.files.grep(/^exe\//) { |f| File.basename(f) }
   s.test_files    = s.files.grep(/^spec\//)
   s.require_paths = ['lib']
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'
   s.license       = 'BSD-3-Clause'
 
+  s.add_runtime_dependency 'bundler', ['>= 1.11.0', '< 1.17']
+
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
-  s.add_development_dependency 'bundler', '~> 1.11', '>= 1.11.0'
 end

--- a/lib/hellgrid.rb
+++ b/lib/hellgrid.rb
@@ -1,6 +1,9 @@
+require 'bundler'
+require 'find'
 require 'hellgrid/project'
 require 'hellgrid/matrix'
 require 'hellgrid/views/console'
+require 'hellgrid/cli'
 
 module Hellgrid
 end

--- a/lib/hellgrid/cli.rb
+++ b/lib/hellgrid/cli.rb
@@ -1,0 +1,33 @@
+module Hellgrid
+  class CLI
+    def self.start(argv = ARGV)
+      new(argv).start
+    end
+
+    def initialize(argv = ARGV)
+      @argv = argv
+    end
+
+    attr_reader :argv
+
+    def start
+      recursive_search = !!(argv.delete('-r'))
+      folders = argv.empty? ? [Dir.pwd] : argv
+
+      folders.each do |folder|
+        matrix = Hellgrid::Matrix.new
+
+        Find.find(folder) do |path|
+          if File.directory?(path) && File.exists?(File.join(path, 'Gemfile.lock'))
+            matrix.add_project(Hellgrid::Project.new(folder, path))
+            Find.prune unless recursive_search
+          end
+        end
+
+        view = Hellgrid::Views::Console.new(matrix.sorted_by_most_used)
+
+        view.render
+      end
+    end
+  end
+end

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
.. it is a runtime dependencies because we parse Gemfiles with it ..

On 0.3.0 when you do `gem install hellgrid` and run `hellgrid` you'll
get an error:

```
$ hellgrid
Could not find diff-lcs-1.2.5 in any of the sources
Run `bundle install` to install missing gems.
```