### PR TITLE
Install git when running the ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     <<: *defaults
     steps:
+      - run: apk --no-cache add git
       - checkout
       - restore_cache:
           key: hellgrid-{{ checksum "hellgrid.gemspec" }}
@@ -31,6 +32,7 @@ jobs:
   deploy:
     <<: *defaults
     steps:
+      - run: apk --no-cache add git
       - checkout
       - restore_cache:
           key: hellgrid-{{ checksum "hellgrid.gemspec" }}


### PR DESCRIPTION
It manages to clone the project but when working with tags it started failing
for some reason:

```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
object not found
Counting objects: 196, done.
Compressing objects: 100% (22/22), done.
Total 196 (delta 10), reused 24 (delta 7), pack-reused 164
```