### PR TITLE
Install openssh-client so github.com could be added to known_hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     <<: *defaults
     steps:
       - &install_packages
-        run: apk --no-cache add curl git
+        run: apk --no-cache add curl git openssh-client
       - checkout
       - &restore_gems
         restore_cache:


### PR DESCRIPTION
```
~/hellgrid # git pull origin master
fatal: cannot run ssh: No such file or directory
fatal: unable to fork

~/hellgrid # apk add openssh-client
(1/2) Installing openssh-keygen (7.5_p1-r8)
(2/2) Installing openssh-client (7.5_p1-r8)
Executing busybox-1.27.2-r11.trigger
OK: 50 MiB in 42 packages

~/hellgrid # git pull origin master
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)?
```

Or when circleci installs the thing:

```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
Counting objects: 263, done.
Compressing objects: 100% (13/13), done.
Total 263 (delta 1), reused 9 (delta 0), pack-reused 248
object not found
```