### PR TITLE
Allow any version of bundler < 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     <<: *defaults
     steps:
       - &install_packages
-        run: apk --no-cache add curl git openssh-client
+        run: apk --no-cache add curl git openssh-client make gcc libc-dev
       - checkout
       - &restore_gems
         restore_cache:

--- a/hellgrid.gemspec
+++ b/hellgrid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/FundingCircle/hellgrid'
   s.license       = 'BSD-3-Clause'
 
-  s.add_runtime_dependency 'bundler', '>= 1.11.0', '< 2.1'
+  s.add_runtime_dependency 'bundler', '>= 1.11.0', '< 3'
 
   s.add_development_dependency 'rspec', '~> 3.8.0'
   s.add_development_dependency 'simplecov', '~> 0.16.0'

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.3.4'
+  VERSION = '0.3.5'
 end

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe 'bin/hellgrid' do
+  def with_unbundled_env(&block)
+    if Bundler.respond_to?(:with_unbundled_env)
+      Bundler.with_unbundled_env(&block)
+    else
+      Bundler.with_clean_env(&block)
+    end
+  end
+
   before do
     delete_tmp_folder
 
@@ -88,7 +96,7 @@ TABLE
    rspec-support    |   x    | 3.0.4  
 TABLE
 
-    Bundler.with_clean_env do
+    with_unbundled_env do
       expect(`cd ~ && #{PROJECT_ROOT}/bin/hellgrid #{PROJECT_ROOT}/spec/tmp`).to eq(expected_result)
     end
   end
@@ -106,14 +114,14 @@ TABLE
    rspec-support    |   x    | 3.0.4  
 TABLE
 
-    Bundler.with_clean_env do
+    with_unbundled_env do
       expect(`cd #{PROJECT_ROOT}/spec/tmp && #{PROJECT_ROOT}/bin/hellgrid`).to eq(expected_result)
     end
   end
 
   context 'when passing -r' do
     it 'searches recursively within folders if you flag it to' do
-      Bundler.with_clean_env do
+      with_unbundled_env do
         expect(`cd #{PROJECT_ROOT} && #{PROJECT_ROOT}/bin/hellgrid -r`.lines.first).to(
           include(
             'hellgrid',


### PR DESCRIPTION
There was some deprecation warning:

```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`
```