### PR TITLE
Add a way to transpose the matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ gem install hellgrid
 Let say that you have a directory `/path/to/root/dir` somewhere in which the Ruby projects `foo` and `bar` could be found.
 
 Executing:
+
 ```bash
 hellgrid /path/to/root/dir
 ```
 
 To search recursively (should you have nested projects), use the `-r ` flag:
-```
+
+```bash
 hellgrid -r /path/to/root/dir
 ```
 
@@ -35,7 +37,21 @@ Should result in:
         rspec-mocks        | 2.0.0  | 3.0.4
            rake            | 10.0.0 | 11.1.0
        rspec-support       |   x    | 3.0.4
-          hellgrid         |   x    |   x
+```
+
+To have the gems as columns, use the `-t` flag:
+
+```bash
+hellgrid -t /path/to/root/dir
+```
+
+Should result in:
+
+```bash
+   x    | diff-lcs |  rake  | rspec | rspec-core | rspec-expectations | rspec-mocks | rspec-support
+--------+----------+--------+-------+------------+--------------------+-------------+---------------
+  bar   |  1.2.5   | 10.0.0 | 2.0.0 |   2.0.0    |       2.0.0        |    2.0.0    |       x
+  foo   |  1.2.5   | 11.1.0 | 3.0.0 |   3.0.4    |       3.0.4        |    3.0.4    |     3.0.4
 ```
 
 ## License

--- a/lib/hellgrid/cli.rb
+++ b/lib/hellgrid/cli.rb
@@ -12,6 +12,8 @@ module Hellgrid
 
     def start
       recursive_search = !!(argv.delete('-r'))
+      transpose = !!(argv.delete('-t'))
+
       folders = argv.empty? ? [Dir.pwd] : argv
 
       folders.each do |folder|
@@ -24,7 +26,10 @@ module Hellgrid
           end
         end
 
-        view = Hellgrid::Views::Console.new(matrix.sorted_by_most_used)
+        data = matrix.sorted_by_most_used
+        data = data.transpose if transpose
+
+        view = Hellgrid::Views::Console.new(data)
 
         view.render
       end

--- a/lib/hellgrid/version.rb
+++ b/lib/hellgrid/version.rb
@@ -1,3 +1,3 @@
 module Hellgrid
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/hellgrid_spec.rb
+++ b/spec/hellgrid_spec.rb
@@ -132,4 +132,19 @@ TABLE
       end
     end
   end
+
+  context 'when passing -t' do
+    it 'transposes the result and the project names on the left' do
+      expected_result = <<-TABLE
+   x    | diff-lcs |  rake  | rspec | rspec-core | rspec-expectations | rspec-mocks | rspec-support 
+--------+----------+--------+-------+------------+--------------------+-------------+---------------
+  bar   |  1.2.5   | 10.0.0 | 2.0.0 |   2.0.0    |       2.0.0        |    2.0.0    |       x       
+ in/foo |  1.2.5   | 11.1.0 | 3.0.0 |   3.0.4    |       3.0.4        |    3.0.4    |     3.0.4     
+TABLE
+
+      with_unbundled_env do
+        expect(`cd #{PROJECT_ROOT}/spec/tmp && #{PROJECT_ROOT}/bin/hellgrid -t`).to eq(expected_result)
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
./bin/hellgrid -r -t
         x        | diff-lcs | rspec | rspec-core | rspec-expectations | rspec-mocks |  rake  | rspec-support | hellgrid
------------------+----------+-------+------------+--------------------+-------------+--------+---------------+----------
         hellgrid |  1.5.1   | 3.8.0 |   3.8.2    |       3.8.6        |    3.8.2    |   x    |     3.8.3     |  0.4.0
     spec/tmp/bar |  1.2.5   | 2.0.0 |   2.0.0    |       2.0.0        |    2.0.0    | 10.0.0 |       x       |    x
  spec/tmp/in/foo |  1.2.5   | 3.0.0 |   3.0.4    |       3.0.4        |    3.0.4    | 11.1.0 |     3.0.4     |    x
```